### PR TITLE
Updated cli-go to 0.5.1

### DIFF
--- a/Formula/deploifai.rb
+++ b/Formula/deploifai.rb
@@ -5,21 +5,21 @@
 class Deploifai < Formula
   desc "CLI tool for Deploifai"
   homepage "https://deploif.ai"
-  version "0.5.0-alpha-10"
+  version "0.5.1"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Darwin_x86_64.tar.gz"
-      sha256 "63e1633a66bff8a5fe16458558788af27f260e9c263a8bff01abe60737e09326"
+      url "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Darwin_x86_64.tar.gz"
+      sha256 "8d3db419f1e08c1a6068f424df19cc10ce0d039bb1d288f4fc0601e89ddfe26f"
 
       def install
         bin.install "deploifai"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Darwin_arm64.tar.gz"
-      sha256 "58d469be8bc95f266b8660b71f6f6488ed85d9941ef3ef5d6e25bad7451a0f6f"
+      url "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Darwin_arm64.tar.gz"
+      sha256 "207f117636fa7779a867904eb2bbb3b23014006a7b0866d9c6eb55a8e910183d"
 
       def install
         bin.install "deploifai"
@@ -29,16 +29,16 @@ class Deploifai < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Linux_arm64.tar.gz"
-      sha256 "b875a38c3adf4331e6def463d7b720bb266593b29db20ee6ae8cda0dc7f9be1f"
+      url "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Linux_arm64.tar.gz"
+      sha256 "dee552053e360649f5f4d73bcd58dbb87350ada4e39688a240f64aecfc9658ee"
 
       def install
         bin.install "deploifai"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Linux_x86_64.tar.gz"
-      sha256 "05e9717cc88110b5f63fea14d144120a6c744eae0e3c5733f046b510cd43eb90"
+      url "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Linux_x86_64.tar.gz"
+      sha256 "83c8edcc0568bd0810f9a15ff9332a3b30411726cc2b6a7f3aa120f0df1daac1"
 
       def install
         bin.install "deploifai"


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)